### PR TITLE
[Bug] Unable to start backend due to dependency error

### DIFF
--- a/backend/src/modules/mail/mail.module.ts
+++ b/backend/src/modules/mail/mail.module.ts
@@ -2,11 +2,6 @@ import { Module } from '@nestjs/common';
 import { MailService } from './mail.service';
 import { MailerModule } from '@nestjs-modules/mailer';
 import { join } from 'path';
-jest.mock('@nestjs-modules/mailer/dist/adapters/handlebars.adapter', () => {
-  return {
-    HandlebarsAdapter: jest.fn().mockImplementation(),
-  };
-});
 import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
 import { config } from 'dotenv';
 

--- a/backend/test/utils/testUtils.ts
+++ b/backend/test/utils/testUtils.ts
@@ -1,3 +1,9 @@
+jest.mock('@nestjs-modules/mailer/dist/adapters/handlebars.adapter', () => {
+  return {
+    HandlebarsAdapter: jest.fn().mockImplementation(),
+  };
+});
+
 import { INestApplication, Type } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModuleBuilder } from '@nestjs/testing';


### PR DESCRIPTION
# Description

Fixes an issue where mocking a library did not allow to start the server due to jest being devDependencies, not dependency

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe)

# How Has This Been Tested?

- Ran `npm run start:dev` and verified backend is starting

# Checklist:

Some items, but not limited, to consider:

- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
